### PR TITLE
Update urls.py to support Django 1.10

### DIFF
--- a/topnotchdev/files_widget/urls.py
+++ b/topnotchdev/files_widget/urls.py
@@ -1,9 +1,11 @@
 try:
-    from django.conf.urls.defaults import patterns, url
+    from django.conf.urls.defaults import url
 except ImportError:
-    from django.conf.urls import patterns, url
+    from django.conf.urls import url
 
-urlpatterns = patterns("topnotchdev.files_widget.views",
+from .views import upload, thumbnail_url
+
+urlpatterns = [
     url(u'^upload/$', "upload", name="files_widget_upload"),
     url(u'^thumbnail-url/$', "thumbnail_url", name="files_widget_get_thumbnail_url"),
-)
+]


### PR DESCRIPTION
Removed patterns() which was deprecated in 1.8 and removed in 1.10.